### PR TITLE
Feature/is app cache ready

### DIFF
--- a/android/IconCacheManager.java
+++ b/android/IconCacheManager.java
@@ -17,7 +17,7 @@ import java.util.HashSet;
 
 public class IconCacheManager {
 
-    private static final HashSet<String> isIconCached = new HashSet<String>();
+    public static final HashSet<String> isIconCached = new HashSet<String>();
     private static File cacheDir = null;
 
     public static String getIcon(Context context, PackageManager packageManager, String packageName) {

--- a/android/SugarizerOSPlugin.java
+++ b/android/SugarizerOSPlugin.java
@@ -205,7 +205,7 @@ public class SugarizerOSPlugin extends CordovaPlugin {
             this.runSettings(callbackContext);
         } else if (action.equals("isAppCacheReady")) {
           JSONObject jsonObject = new JSONObject();
-          jsonObject.put("ready", IconCacheManager.HasCache() && !packageNameToName.isEmpty());
+          jsonObject.put("ready", !IconCacheManager.isIconCached.isEmpty() && !packageNameToName.isEmpty());
           callbackContext.success(jsonObject);
           return true;
         } else if (action.equals("apps")) {

--- a/android/SugarizerOSPlugin.java
+++ b/android/SugarizerOSPlugin.java
@@ -203,6 +203,11 @@ public class SugarizerOSPlugin extends CordovaPlugin {
             this.runActivity(callbackContext, args.getString(0));
         } else if (action.equals("runSettings")) {
             this.runSettings(callbackContext);
+        } else if (action.equals("isAppCacheReady")) {
+          JSONObject jsonObject = new JSONObject();
+          jsonObject.put("ready", IconCacheManager.HasCache() && !packageNameToName.isEmpty());
+          callbackContext.success(jsonObject);
+          return true;
         } else if (action.equals("apps")) {
             this.getApps(callbackContext, args.getInt(0));
             return true;

--- a/sugarizeros.js
+++ b/sugarizeros.js
@@ -84,7 +84,7 @@ sugarizerOS.init = function(){
 	console.log("SugarizerOS initialized");
 	sugarizerOS.getLauncherPackageName(function(value) {sugarizerOS.launcherPackageName = value;});
 	sugarizerOS.getKeyStore(function(value){sugarizerOS.keyStore = value;}, function(error){sugarizerOS.resetKeyStore();sugarizerOS.init();});
-	sugarizerOS.getInt(function(value){sugarizerOS.isSetup == (value == 1);}, null, "IS_SETUP"); 
+	sugarizerOS.getInt(function(value){sugarizerOS.isSetup == (value == 1);}, null, "IS_SETUP");
     }
     else{
 	console.log("No window to initialize sugarizerOS");
@@ -163,6 +163,10 @@ sugarizerOS.runSettings = function(){
     exec(null, null, "SugarizerOSPlugin", "runSettings", []);
 }
 
+sugarizerOS.isAppCacheReady = function(onSuccess) {
+    exec(onSuccess, null, "SugarizerOSPlugin", "isAppCacheReady", []);
+}
+
 sugarizerOS.applicationsToActivities = function(applications){
     var activities = [];
     for (i = 0; i < applications.length; i++){
@@ -234,9 +238,9 @@ sugarizerOS.initActivitiesPreferences = function(callback){
 	}
     }
 	, null, [0]);
-				      
+
 }
-    
+
 sugarizerOS.log = function(m){
     console.log(m);
 }


### PR DESCRIPTION
Added isAppCacheReady to know if there is a native app cache.

Sample code : 
sugarizerOS.isAppCacheReady(function(response) {
  console.log("IsAppReady : " + response.ready);
})

ready is a boolean

To try the functionality, you can call the sampleCode 
- inside the homeview, before initActivitiesPreferences
- inside the homeview, in the init function

The first call should return response.ready => false
The second call should return response.ready => true 
